### PR TITLE
pcp pmcd agent embedding

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,18 @@ RUN npm install --production
 COPY . .
 
 RUN chmod -R +777 /home/${F8_USER_NAME}
-USER ${F8_USER_NAME}
 
+# Install little pcp pmcd server for metrics collection
+# would prefer only pmcd, and not the /bin/pm*tools etc.
+COPY pcp.repo /etc/yum.repos.d/pcp.repo
+RUN yum install -y pcp && yum clean all && \
+    mkdir -p /etc/pcp /var/run/pcp /var/lib/pcp /var/log/pcp  && \
+    chgrp -R root /etc/pcp /var/run/pcp /var/lib/pcp /var/log/pcp && \
+    chmod -R g+rwX /etc/pcp /var/run/pcp /var/lib/pcp /var/log/pcp
+COPY ./node+pmcd.sh /node+pmcd.sh
+EXPOSE 44321
+
+USER ${F8_USER_NAME}
 EXPOSE 8080
 
-CMD node index.js
+CMD /node+pmcd.sh

--- a/node+pmcd.sh
+++ b/node+pmcd.sh
@@ -1,0 +1,44 @@
+#! /bin/sh
+
+set -eu
+
+# Initialize a little unprivileged pcp pmcd metrics collector
+# process within this container; run this in a background subshell.
+# No special signal handling or cleanup required.
+(
+# Setup pmcd to run in unprivileged mode of operation
+. /etc/pcp.conf
+
+PATH=$PATH:$PCP_BINADM_DIR
+export PATH
+
+# Configure pmcd with a minimal set of DSO agents
+rm -f $PCP_PMCDCONF_PATH; # start empty
+echo "# Name  ID  IPC  IPC Params  File/Cmd" >> $PCP_PMCDCONF_PATH;
+echo "pmcd     2  dso  pmcd_init   $PCP_PMDAS_DIR/pmcd/pmda_pmcd.so"   >> $PCP_PMCDCONF_PATH;
+echo "proc     3  dso  proc_init   $PCP_PMDAS_DIR/proc/pmda_proc.so"   >> $PCP_PMCDCONF_PATH;
+echo "linux   60  dso  linux_init  $PCP_PMDAS_DIR/linux/pmda_linux.so" >> $PCP_PMCDCONF_PATH;
+
+rm -f $PCP_VAR_DIR/pmns/root_xfs $PCP_VAR_DIR/pmns/root_jbd2 $PCP_VAR_DIR/pmns/root_root $PCP_VAR_DIR/pmns/root
+touch $PCP_VAR_DIR/pmns/.NeedRebuild
+
+# allow unauthenticated access to proc.* metrics (default is false)
+export PROC_ACCESS=1
+export PMCD_ROOT_AGENT=0
+
+# NB: we can't use the rc.pmcd script.  It assumes that it's run as root.
+cd $PCP_VAR_DIR/pmns
+./Rebuild
+
+cd $PCP_LOG_DIR
+
+: "${PCP_HOSTNAME:=`hostname`}"
+# possibly: filter pod name?
+
+# We can log in plaintext to stdout also, even though WIT uses
+# JSON.  pmcd is not chatty and only speaks up during errors.
+exec /usr/libexec/pcp/bin/pmcd -l /dev/force-logging-to-stderr -f -A -H $PCP_HOSTNAME
+) &
+sleep 5 # give time for pmcd's startup messages, so it doesn't intermix with CMD's
+
+exec node index.js

--- a/pcp.repo
+++ b/pcp.repo
@@ -1,0 +1,10 @@
+[fche-pcp]
+name=Copr repo for pcp owned by fche
+baseurl=https://copr-be.cloud.fedoraproject.org/results/fche/pcp/epel-7-$basearch/
+type=rpm-md
+skip_if_unavailable=True
+gpgcheck=1
+gpgkey=https://copr-be.cloud.fedoraproject.org/results/fche/pcp/pubkey.gpg
+repo_gpgcheck=0
+enabled=1
+enabled_metadata=1


### PR DESCRIPTION
Add background pmcd process, in order to enable feeding of
process/system level data about this pod to a nearby pcp collector.