### PR TITLE
Build on RHEL

### DIFF
--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,0 +1,22 @@
+FROM prod.registry.devshift.net/osio-prod/base/nodejs:latest
+LABEL maintainer "Devtools <devtools@redhat.com>"
+LABEL author "Devtools <devtools@redhat.com>"
+
+ENV F8_USER_NAME=fabric8
+RUN useradd  -s /bin/bash ${F8_USER_NAME}
+
+WORKDIR /home/${F8_USER_NAME}
+COPY package.json .
+RUN npm install --production
+
+COPY . .
+
+RUN chmod -R +777 /home/${F8_USER_NAME}
+
+COPY ./node+pmcd.sh /node+pmcd.sh
+EXPOSE 44321
+
+USER ${F8_USER_NAME}
+EXPOSE 8080
+
+CMD /node+pmcd.sh


### PR DESCRIPTION
Enable build on RHEL if TARGET=rhel.

The cico environment will continue to build the CentOS based container and in a second step it will build and push a RHEL based container. As of now, the CentOS containers will be the ones being deployed to prod-preview and prod.

Additionally, the nodejs image is not yet available installed, waiting on:
https://github.com/rhdt/EL-Dockerfiles/pull/5/files

This PR will remain as a WIP until this PR is merged and validated:
https://github.com/fabric8-services/fabric8-auth/pull/432