### PR TITLE
Adds IMAGE param to OpenShift template

### DIFF
--- a/openshift/OpenShiftTemplate.yml
+++ b/openshift/OpenShiftTemplate.yml
@@ -67,7 +67,7 @@ objects:
               secretKeyRef:
                 name: f8toggles
                 key: github.auth.team                                           
-          image: registry.devshift.net/fabric8-services/fabric8-toggles:${IMAGE_TAG}
+          image: ${IMAGE}:${IMAGE_TAG}
           imagePullPolicy: Always
           name: f8toggles
           ports:
@@ -110,5 +110,7 @@ objects:
     selector:
       deploymentconfig: f8toggles
 parameters:
+- name: IMAGE
+  value: registry.devshift.net/fabric8-services/fabric8-toggles
 - name: IMAGE_TAG
   value: latest


### PR DESCRIPTION
This PR is part of an effort to migrate the services running in OSIO from CentOS
to RHEL.

This commit adds IMAGE as an environment parameter.

It enables the possibility of defining different urls for the image in staging
and prod.